### PR TITLE
Z and Synplicity downloads, fallback on Torrent

### DIFF
--- a/SRCustomLib/CustomMapRepoTorrent.cs
+++ b/SRCustomLib/CustomMapRepoTorrent.cs
@@ -194,7 +194,7 @@ namespace SRCustomLib
         /// <param name="manager"></param>
         /// <param name="toDownload"></param>
         /// <returns></returns>
-        private async Task<List<MapZMetadata>> DownloadInternal(TorrentManager manager, List<ITorrentManagerFile> toDownload)
+        private async Task<List<MapZMetadata>?> DownloadInternal(TorrentManager manager, List<ITorrentManagerFile> toDownload)
         {
             List<MapZMetadata> downloadedMaps = new List<MapZMetadata>();
             

--- a/SRCustomLib/CustomMapRepoTorrent.cs
+++ b/SRCustomLib/CustomMapRepoTorrent.cs
@@ -258,7 +258,7 @@ namespace SRCustomLib
             // Only bother with imports and db updates if there were actually any new songs updated
             if (downloadedMaps.Count > 0)
             {
-                await _customFileManager.AddLocalMaps(downloadedMaps.Select(mapMetadata => mapMetadata.FilePath).ToList());
+                // await _customFileManager.AddLocalMaps(downloadedMaps.Select(mapMetadata => mapMetadata.FilePath).ToList());
                 var numProcessed = 0;
                 foreach (var map in downloadedMaps)
                 {

--- a/SRCustomLib/CustomMapRepoTorrent.cs
+++ b/SRCustomLib/CustomMapRepoTorrent.cs
@@ -145,7 +145,7 @@ namespace SRCustomLib
                 // Check time. If there's no time, then assume it's newer than the site or cached list, so should be downloaded
                 if (mapMetadata.PublishedAtTimestampSec > 0 && mapMetadata.PublishedAtTimestampSec < startTimestampSec)
                 {
-                    _logger.DebugLog($"Published time {mapMetadata.PublishedAtTimestampSec} < {startTimestampSec}; skipping");
+                    // _logger.DebugLog($"Published time {mapMetadata.PublishedAtTimestampSec} < {startTimestampSec}; skipping");
                     continue;
                 }
 

--- a/SRCustomLib/CustomMapRepoTorrent.cs
+++ b/SRCustomLib/CustomMapRepoTorrent.cs
@@ -104,8 +104,8 @@ namespace SRCustomLib
         /// </summary>
         /// <param name="includedDifficulties">If set, only download songs that have one of the included difficulties. If null, download all difficulties.</param>
         /// <param name="startTime">Only maps published after this time will be included. Default is 0, so all maps.</param>
-        /// <returns></returns>
-        public async Task<List<MapZMetadata>> DownloadMaps(HashSet<string>? includedDifficulties = null, DateTimeOffset startTime = default)
+        /// <returns>Downloaded map data, or empty list if none found. Returns null on error.</returns>
+        public async Task<List<MapZMetadata>?> DownloadMaps(HashSet<string>? includedDifficulties = null, DateTimeOffset startTime = default)
         {
             var downloadedMaps = new List<MapZMetadata>();
             var startTimestampSec = startTime.ToUnixTimeSeconds();
@@ -113,7 +113,7 @@ namespace SRCustomLib
             // Prep for download
             var manager = await GetManagerAllDoNotDownload();
             if (manager == null)
-                return new List<MapZMetadata>();
+                return null;
 
             _logger.DebugLog("Filtering maps...");
 
@@ -193,7 +193,7 @@ namespace SRCustomLib
             if (!success)
             {
                 _logger.ErrorLog("Download failed!");
-                return new List<MapZMetadata>();
+                return null;
             }
 
             _logger.DebugLog("Done downloading. Moving files...");

--- a/SRCustomLib/DownloadManagerSyn.cs
+++ b/SRCustomLib/DownloadManagerSyn.cs
@@ -1,6 +1,14 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
 using SRTimestampLib;
 using SRTimestampLib.Models;
+
+// Avoid annoying warnings in Unity
+#nullable enable
 
 namespace SRCustomLib
 {

--- a/SRCustomLib/DownloadManagerSyn.cs
+++ b/SRCustomLib/DownloadManagerSyn.cs
@@ -1,0 +1,71 @@
+﻿using Newtonsoft.Json;
+using SRTimestampLib;
+using SRTimestampLib.Models;
+
+namespace SRCustomLib
+{
+    /// <summary>
+    /// Handles custom map downloading via Synplicity API.
+    /// It's mostly compatible with the Z format, so subclassing instead of making a whole new class.
+    /// </summary>
+    public class DownloadManagerSyn : DownloadManagerZ
+    {
+        public DownloadManagerSyn(SRLogHandler logger, CustomFileManager customFileManager) : base(logger, customFileManager) { }
+
+        public override string GetDownloadUrl(MapItem map)
+        {
+            return "https://api.synplicity.live/" + map.download_url;
+        }
+
+        public override string MapPageUrl => "https://api.synplicity.live/beatmaps";
+
+        /// <summary>
+        /// Gets a single page of map metadata, with the given filters
+        /// </summary>
+        /// <param name="pageSize"></param>
+        /// <param name="pageIndex"></param>
+        /// <param name="sinceTime"></param>
+        /// <param name="includedDifficulties"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public override async Task<MapPage?> GetMapPage(int pageSize, int pageIndex, DateTimeOffset sinceTime, List<string>? includedDifficulties, CancellationToken cancellationToken = default)
+        {
+            var apiEndpoint = MapPageUrl;
+            var sort = "published_at,DESC";
+
+            string sinceTimeIso8601 = sinceTime.ToString("s", System.Globalization.CultureInfo.InvariantCulture);
+            // string difficultiesArray = string.Join(",", includedDifficulties.Select(diff => diff.ToLowerInvariant()));
+            // string difficultiesParam = includedDifficulties.Count > 0 ? $"&difficulties={difficultiesArray}" : "";
+            string difficultiesParam = "";
+            if (includedDifficulties != null && includedDifficulties.Count > 0)
+            {
+                difficultiesParam = "&difficulties=" + string.Join(",", includedDifficulties.Select(diff => diff.ToLowerInvariant()));
+                // foreach (var diff in includedDifficulties)
+                // {
+                //     difficultiesParam += $"&difficulties={diff.ToLowerInvariant()}";
+                // }
+            }
+
+            string request = $"{apiEndpoint}?sort={sort}&limit={pageSize}&page={pageIndex}&date_after={sinceTimeIso8601}{difficultiesParam}";
+            var requestUri = new Uri(request);
+            string? rawPage = await HttpUtils.Instance.GetStringAsync(requestUri, GET_PAGE_TIMEOUT_SEC, logger, cancellationToken);
+            if (string.IsNullOrEmpty(rawPage))
+            {
+                logger.ErrorLog($"Failed to get map page {pageIndex}, url {requestUri}");
+                return null;
+            }
+
+            logger.DebugLog("Deserializing page...");
+            try
+            {
+                MapPage? page = JsonConvert.DeserializeObject<MapPage>(rawPage);
+                return page;
+            }
+            catch (System.Exception e)
+            {
+                logger.ErrorLog($"Failed to deserialize map page: {e.Message}");
+                return null;
+            }
+        }
+    }
+}

--- a/SRCustomLib/DownloadManagerZ.cs
+++ b/SRCustomLib/DownloadManagerZ.cs
@@ -1,0 +1,288 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using SRTimestampLib;
+using SRTimestampLib.Models;
+
+namespace SRCustomLib
+{
+    /// <summary>
+    /// Handles map downloads through the Z site
+    /// </summary>
+    public class DownloadManagerZ
+    {
+        public SRLogHandler logger;
+        public CustomFileManager customFileManager;
+        
+        protected const int GET_PAGE_TIMEOUT_SEC = 3; // In case the site is down, fail quick
+        protected const int GET_MAP_TIMEOUT_SEC = 60;
+        protected const int PARALLEL_DOWNLOAD_LIMIT = 10;
+
+        public DownloadManagerZ(SRLogHandler logger, CustomFileManager customFileManager)
+        {
+            this.logger = logger;
+            this.customFileManager = customFileManager;
+        }
+
+        public virtual string GetDownloadUrl(MapItem map)
+        {
+            return "https://synthriderz.com" + map.download_url;
+        }
+
+        public virtual string MapPageUrl => "https://synthriderz.com/api/beatmaps";
+
+        /// <summary>
+        /// Tries to download all songs from Z with any of the given difficulties and published after the given time.
+        /// </summary>
+        /// <param name="sinceTime"></param>
+        /// <param name="selectedDifficulties"></param>
+        /// <returns>True if successfully downloaded (or attempted but none to download). False on failure (i.e. Z is down)</returns>
+        public async Task<bool> DownloadSongsSinceTime(DateTimeOffset sinceTime, List<string>? selectedDifficulties) {
+            logger.DebugLog($"Getting maps after time {sinceTime.ToLocalTime()}...");
+
+            var tempDir = Path.Join(FileUtils.TempPath, "Download");
+            try {
+                // Delete anything from previous runs
+                if (Directory.Exists(tempDir)) {
+                    logger.DebugLog($"Clearing temp directory at {tempDir}");
+                    Directory.Delete(tempDir, true);
+                }
+
+                // Recreate
+                logger.DebugLog($"(re)Creating temp directory at {tempDir}");
+                Directory.CreateDirectory(tempDir);
+            }
+            catch (System.Exception e) {
+                logger.ErrorLog("Failed to delete or create temp dir: " + e.Message);
+                return false;
+            }
+            
+            try {
+                List<MapItem>? mapsFromSite = await GetMapsSinceTimeForDifficulties(sinceTime, selectedDifficulties);
+                if (mapsFromSite == null)
+                {
+                    return false;
+                }
+                
+                logger.DebugLog($"{mapsFromSite.Count} maps found since given time for given difficulties.");
+
+                var mapsToDownload = customFileManager.FilterOutExistingMaps(mapsFromSite);
+                logger.DebugLog($"{mapsToDownload.Count} new files to download...");
+
+                int count = 1;
+                var downloadTasks = new Queue<Task<bool>>();
+                foreach (MapItem map in mapsToDownload) {
+                    logger.DebugLog($"{count}/{mapsToDownload.Count}: {map.id} {map.title}");
+
+                    downloadTasks.Enqueue(DownloadMap(map, tempDir));
+                    count++;
+
+                    // Limit the number of simultaneous downloads
+                    while (downloadTasks.Count > PARALLEL_DOWNLOAD_LIMIT) {
+                        // logger.DebugLog($"More than {PARALLEL_DOWNLOAD_LIMIT} downloads queued, waiting...");
+                        // This is safe since we aren't adding any more to this while we wait
+                        await downloadTasks.Dequeue();
+                    }
+
+                    // Every so often for bulk downloads, save the database
+                    if (count % 100 == 0) {
+                        logger.DebugLog("Stopping new queued downloads...");
+                        while (downloadTasks.Count > 0) {
+                            await downloadTasks.Dequeue();
+                        }
+
+                        logger.DebugLog("Saving current state to db...");
+                        await customFileManager.db.Save();
+
+                        logger.DebugLog("Resuming...");
+                    }
+                }
+
+                // Wait for last downloads
+                logger.DebugLog("Waiting for last downloads...");
+                while (downloadTasks.Count > 0) {
+                    await downloadTasks.Dequeue();
+                }
+                logger.DebugLog("Done waiting");
+
+                logger.DebugLog("Trying to save database...");
+                await customFileManager.db.Save(true);
+                logger.DebugLog("Done");
+            }
+            catch (System.Exception e) {
+                logger.ErrorLog($"Failed to download maps: {e.Message}");
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Downloads the given MapItem to the destination directory
+        /// Returns true if successful, false if not
+        /// </summary>
+        /// <param name="map"></param>
+        /// <param name="destDir"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public async Task<bool> DownloadMap(MapItem map, string destDir, CancellationToken cancellationToken = default)
+        {
+            var fullUrl = GetDownloadUrl(map);
+            var destPath = Path.Join(destDir, map.filename);
+
+            try {
+                byte[]? rawMapData = await HttpUtils.Instance.GetBytesAsync(new Uri(fullUrl), GET_MAP_TIMEOUT_SEC, logger, cancellationToken);
+                if (rawMapData == null || rawMapData.Length == 0) {
+                    logger.ErrorLog($"Error getting map data from {fullUrl}");
+                    return false;
+                }
+
+                // logger.DebugLog("Saving to file...");
+                if (false == await FileUtils.WriteToFile(rawMapData, destPath, logger)) {
+                    return false;
+                }
+
+                // logger.DebugLog("Moving to SynthRiders directory...");
+                string finalPath = customFileManager.MoveCustomSong(destPath, map.GetPublishedAtUtc());
+
+                // logger.DebugLog("Success!");
+                await customFileManager.AddLocalMap(finalPath, map);
+                
+                // Wait for all other operations to finish, then ensure the timestamp has been set
+                await Task.Yield();
+                if (map.GetPublishedAtUtc().HasValue)
+                {
+                    FileUtils.TrySetDateModifiedUtc(finalPath, map.GetPublishedAtUtc().GetValueOrDefault(), logger);
+                }
+
+                return true;
+            }
+            catch (System.Exception e) {
+                logger.ErrorLog($"Failed to download map {map.id} ({map.title}): {e.Message}");
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Gets one page of map metdata, with the given filters
+        /// </summary>
+        /// <param name="pageSize"></param>
+        /// <param name="pageIndex"></param>
+        /// <param name="sinceTime"></param>
+        /// <param name="includedDifficulties"></param>
+        /// <returns></returns>
+        public virtual async Task<MapPage?> GetMapPage(int pageSize, int pageIndex, DateTimeOffset sinceTime, List<string>? includedDifficulties, CancellationToken cancellationToken = default)
+        {
+            var apiEndpoint = MapPageUrl;
+            var sort = "published_at,DESC";
+
+            JArray searchParameters = new JArray();
+
+            var publishedDateRange = new JObject(
+                new JProperty("published_at",
+                    new JObject(
+                        new JProperty("$gt",
+                            new JValue(sinceTime.UtcDateTime)
+                        )
+                    )
+                )
+            );
+
+            var beatSaberConvert = new JObject(
+                new JProperty("beat_saber_convert",
+                    new JObject(
+                        new JProperty("$ne",
+                            new JValue(true)
+                        )
+                    )
+                )
+            );
+
+            searchParameters.Add(publishedDateRange);
+            searchParameters.Add(beatSaberConvert);
+
+            if (includedDifficulties != null)
+            {
+                var difficultyFilter = new JObject(
+                    new JProperty("difficulties",
+                        new JObject(
+                            new JProperty("$jsonContainsAny",
+                                new JArray(includedDifficulties)
+                            )
+                        )
+                    )
+                );
+                searchParameters.Add(difficultyFilter);
+            }
+
+            var searchFilter = new JObject(
+                new JProperty("$and", searchParameters)
+            );
+
+            string request = $"{apiEndpoint}?sort={sort}&limit={pageSize}&page={pageIndex}&s={searchFilter.ToString(Formatting.None)}";
+            var requestUri = new Uri(request);
+            string? rawPage = await HttpUtils.Instance.GetStringAsync(requestUri, GET_PAGE_TIMEOUT_SEC, logger, cancellationToken);
+            if (string.IsNullOrEmpty(rawPage))
+            {
+                logger.ErrorLog($"Failed to get page at uri {requestUri}");
+                return null;
+            }
+
+            // logger.DebugLog("Deserializing page...");
+            try {
+                MapPage? page = JsonConvert.DeserializeObject<MapPage>(rawPage);
+                return page;
+            }
+            catch (System.Exception e) {
+                logger.ErrorLog($"Failed to deserialize map page: {e.Message}");
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Gets all maps since the given time with one of the given difficulties.
+        /// Returns an empty list if none found, and null if an error occurred.
+        /// </summary>
+        /// <param name="sinceTime"></param>
+        /// <param name="selectedDifficulties"></param>
+        /// <returns></returns>
+        public async Task<List<MapItem>?> GetMapsSinceTimeForDifficulties(DateTimeOffset sinceTime, List<string>? selectedDifficulties) {
+            var maps = new List<MapItem>();
+
+            int numPages = 1;
+            int pageSize = 50;
+            int pageIndex = 1;
+
+            do
+            {
+                if (pageIndex == 1) {
+                    logger.DebugLog("Requesting first page");
+                }
+                else {
+                    logger.DebugLog($"Requesting page {pageIndex}/{numPages}");
+                }
+
+                MapPage? page = await GetMapPage(pageSize, pageIndex, sinceTime, selectedDifficulties);
+                if (page == null) {
+                    logger.ErrorLog($"Returned null page {pageIndex}! Aborting.");
+                    return null;
+                }
+
+                logger.DebugLog($"  Page {pageIndex}/{numPages} retrieved with {page.data.Count} elements");
+                foreach (MapItem item in page.data)
+                {
+                    // For now, don't care about existing files, just overwrite them
+                    maps.Add(item);
+                }
+
+                // Set total page count from responses
+                numPages = page.pagecount;
+
+                pageIndex++;
+            }
+            while (pageIndex <= numPages);
+
+            return maps;
+        }
+    }
+}

--- a/SRCustomLib/HttpUtils.cs
+++ b/SRCustomLib/HttpUtils.cs
@@ -1,8 +1,15 @@
-﻿using SRTimestampLib;
+﻿using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using SRTimestampLib;
 
 #if UNITY_2021_3_OR_NEWER
 using UnityEngine.Networking;
 #endif
+
+// Avoid annoying warnings in Unity
+#nullable enable
 
 namespace SRCustomLib
 {

--- a/SRCustomLib/HttpUtils.cs
+++ b/SRCustomLib/HttpUtils.cs
@@ -1,0 +1,136 @@
+﻿using SRTimestampLib;
+
+#if UNITY_2021_3_OR_NEWER
+using UnityEngine.Networking;
+#endif
+
+namespace SRCustomLib
+{
+    public class HttpUtils
+    {
+        public static HttpUtils Instance { get; } = new();
+
+        private HttpClient _httpClient = new();
+
+        /// <summary>
+        /// Does an HTTP GET and returns the endpoint's response as a raw byte array
+        /// </summary>
+        /// <param name="requestUri"></param>
+        /// <param name="timeoutSec"></param>
+        /// <param name="logger"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public async Task<byte[]?> GetBytesAsync(Uri requestUri, int timeoutSec, SRLogHandler logger, CancellationToken cancellationToken = default)
+        {
+#if UNITY_2021_3_OR_NEWER
+            try {
+                var getRequest = UnityWebRequest.Get(requestUri);
+                getRequest.timeout = timeoutSec;
+                var asyncOp = getRequest.SendWebRequest();
+                var startTime = DateTime.Now;
+                var timeoutTime = startTime.AddSeconds(timeoutSec);
+                while (!asyncOp.isDone) {
+                    if (DateTime.Now > timeoutTime) {
+                        logger.ErrorLog("Timed out waiting for page!");
+                        return null;
+                    }
+                    else {
+                        await Task.Delay(10);
+                    }
+                }
+                if (!string.IsNullOrEmpty(asyncOp.webRequest.error)) {
+                    logger.ErrorLog("Error getting request: " + asyncOp.webRequest.error);
+                    return null;
+                }
+                return getRequest.downloadHandler.data;
+            }
+            catch (System.Exception e) {
+                logger.ErrorLog($"Failed to get web page: {e.Message}");
+                return null;
+            }
+#else
+            try
+            {
+                var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(timeoutSec));
+                cancellationToken.Register(timeoutCts.Cancel);
+                byte[] result = await _httpClient.GetByteArrayAsync(requestUri, timeoutCts.Token);
+                
+                // Apparently never returns as null, and callers might want an empty array.
+                
+                return result;
+            }
+            catch (HttpRequestException e)
+            {
+                logger.ErrorLog("Error getting request: " + e.Message);
+                return null;
+            }
+            catch (System.Exception e) {
+                logger.ErrorLog($"Failed to get web page: {e.Message}");
+                return null;
+            }
+#endif
+        }
+        
+        /// <summary>
+        /// Does an HTTP GET and returns the endpoint's response as a string
+        /// </summary>
+        /// <param name="requestUri"></param>
+        /// <param name="timeoutSec"></param>
+        /// <param name="logger"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public async Task<string?> GetStringAsync(Uri requestUri, int timeoutSec, SRLogHandler logger, CancellationToken cancellationToken = default)
+        {
+#if UNITY_2021_3_OR_NEWER
+            try {
+                var getRequest = UnityWebRequest.Get(requestUri);
+                getRequest.timeout = timeoutSec;
+                var asyncOp = getRequest.SendWebRequest();
+                var startTime = DateTime.Now;
+                var timeoutTime = startTime.AddSeconds(timeoutSec);
+                while (!asyncOp.isDone) {
+                    if (DateTime.Now > timeoutTime) {
+                        logger.ErrorLog("Timed out waiting for page!");
+                        return null;
+                    }
+                    else {
+                        await Task.Delay(10);
+                    }
+                }
+                if (!string.IsNullOrEmpty(asyncOp.webRequest.error)) {
+                    logger.ErrorLog("Error getting request: " + asyncOp.webRequest.error);
+                    return null;
+                }
+                return getRequest.downloadHandler.text;
+            }
+            catch (System.Exception e) {
+                logger.ErrorLog($"Failed to get web page: {e.Message}");
+                return null;
+            }
+#else
+            try
+            {
+                var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(timeoutSec));
+                cancellationToken.Register(timeoutCts.Cancel);
+                string? result = await _httpClient.GetStringAsync(requestUri, timeoutCts.Token);
+                if (string.IsNullOrEmpty(result))
+                {
+                    logger.ErrorLog("No result for request!");
+                    return null;
+                }
+
+                return result;
+            }
+            catch (HttpRequestException e)
+            {
+                logger.ErrorLog("Error getting request: " + e.Message);
+                return null;
+            }
+            catch (System.Exception e) {
+                logger.ErrorLog($"Failed to get web page: {e.Message}");
+                return null;
+            }
+#endif
+        }
+    }
+}

--- a/SRCustomLib/MapMetadataRepo.cs
+++ b/SRCustomLib/MapMetadataRepo.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Newtonsoft.Json;
 using SRCustomLib.Models;
 using SRTimestampLib;
+using SRTimestampLib.Models;
 
 // Avoid annoying warnings in Unity
 #nullable enable
@@ -112,7 +113,7 @@ namespace SRCustomLib
                         string? rawResult = await _client.GetStringAsync(requestUri);
 
                         MapPage? metadataList = string.IsNullOrEmpty(rawResult) ? null : JsonConvert.DeserializeObject<MapPage>(rawResult);
-                        if (metadataList != null && metadataList.data != null && metadataList.data.Count == 1)
+                        if (metadataList != null && metadataList.data.Count == 1)
                         {
                             metadata = MapMetadata.FromMapItem(metadataList.data[0]);
                         }

--- a/SRCustomLib/MapMetadataRepo.cs
+++ b/SRCustomLib/MapMetadataRepo.cs
@@ -1,15 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
-using MonoTorrent;
 using Newtonsoft.Json;
 using SRCustomLib.Models;
 using SRTimestampLib;
-using SRTimestampLib.Models;
-using UnityEditor.AddressableAssets.Settings;
 
 // Avoid annoying warnings in Unity
 #nullable enable

--- a/SRCustomLib/MapMetadataRepo.cs
+++ b/SRCustomLib/MapMetadataRepo.cs
@@ -1,0 +1,142 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+using MonoTorrent;
+using Newtonsoft.Json;
+using SRCustomLib.Models;
+using SRTimestampLib;
+using SRTimestampLib.Models;
+using UnityEditor.AddressableAssets.Settings;
+
+// Avoid annoying warnings in Unity
+#nullable enable
+
+namespace SRCustomLib
+{
+    /// <summary>
+    /// Handles retrieving the latest metadata for maps
+    /// </summary>
+    public class MapMetadataRepo
+    {
+        private const string GET_MAP_METADATA_URL_Z = "https://synthriderz.com/api/beatmaps";
+        private const string GET_MAP_METADATA_URL_SYN = "https://api.synplicity.live/beatmaps";
+        private const string METADATA_CACHE_FILE = "map_metadata.json";
+
+        private readonly SRLogHandler _logger;
+        private readonly HttpClient _client = new();
+
+        private Dictionary<string, MapMetadata> _cachedMetadataByFileName = new();
+        
+        private bool _hasInitialized;
+        private bool _isDirty;
+        
+        private string CachePath => Path.Combine(FileUtils.GetPersistentFolder(), METADATA_CACHE_FILE);
+
+        public MapMetadataRepo(SRLogHandler logger)
+        {
+            _logger = logger;
+        }
+        
+        /// <summary>
+        /// Adds the metadata to the cache, optionally overwriting an existing entry
+        /// </summary>
+        /// <param name="metadata"></param>
+        /// <param name="overwriteExisting"></param>
+        public void AddToCache(MapMetadata metadata, bool overwriteExisting = false)
+        {
+            // TODO consider merging instead?
+            var trimmedName = metadata.FileName!.Trim();
+            if (overwriteExisting || !_cachedMetadataByFileName.ContainsKey(trimmedName))
+            {
+                _cachedMetadataByFileName[trimmedName] = metadata;
+            }
+            _isDirty = true;
+        }
+
+        /// <summary>
+        /// Saves the current state of the cache so it can be loaded on a new run.
+        /// </summary>
+        public async Task PersistCache()
+        {
+            // TODO better cache
+
+            if (_isDirty)
+            {
+                _isDirty = false;
+                _logger.DebugLog("Persisting map metadata...");
+                string serializedCache = JsonConvert.SerializeObject(_cachedMetadataByFileName, Formatting.Indented);
+                await FileUtils.WriteToFile(serializedCache, CachePath, _logger);
+            }
+        }
+
+        public async Task Initialize()
+        {
+            if (_hasInitialized)
+            {
+                return;
+            }
+            
+            _logger.DebugLog("Loading map metadata...");
+            _cachedMetadataByFileName = await FileUtils.ReadFileJson<Dictionary<string, MapMetadata>>(CachePath, _logger) ?? new();
+            _hasInitialized = true;
+        }
+
+        /// <summary>
+        /// Searches cache, then Z, then Syn, for metadata for the map with the given fileName
+        /// </summary>
+        /// <param name="fileName"></param>
+        /// <param name="timeout"></param>
+        /// <returns></returns>
+        public async Task<MapMetadata?> GetMetadataWithFallbacks(string fileName, TimeSpan timeout)
+        {
+            // Check for PublishedAt being 0, in cases of local files having partial metadata
+            if (_cachedMetadataByFileName.TryGetValue(fileName, out var cachedMetadata) && cachedMetadata != null && cachedMetadata.PublishedAtTimestampSec > 0)
+            {
+                return cachedMetadata;
+            }
+            
+            _client.Timeout = timeout;
+
+            try
+            {
+                // First, try for Z
+                var escapedFileName = Uri.EscapeDataString(fileName);
+                string request = GET_MAP_METADATA_URL_Z + "?s={\"filename\":\"" + escapedFileName + "\"}";
+                var requestUri = new Uri(request);
+                string? rawResult = await _client.GetStringAsync(requestUri);
+
+                MapMetadata? metadata = null;
+                MapPage? metadataList = string.IsNullOrEmpty(rawResult) ? null : JsonConvert.DeserializeObject<MapPage>(rawResult);
+                if (metadataList != null && metadataList.data != null && metadataList.data.Count == 1)
+                {
+                    metadata = MapMetadata.FromMapItem(metadataList.data[0]);
+                }
+
+                if (metadata == null)
+                {
+                    // // Fallback on Syn, once that's up and functional
+                    // request = $"{GET_MAP_METADATA_URL_SYN}/{escapedFileName}";
+                    // requestUri = new Uri(request);
+                    // rawResult = await _client.GetStringAsync(requestUri);
+                    // metadata = string.IsNullOrEmpty(rawResult) ? null : JsonConvert.DeserializeObject<MapMetadata>(rawResult);
+                }
+                
+                // If we found metadata, cache it for later
+                if (metadata != null)
+                {
+                    AddToCache(metadata, true);
+                }
+
+                // If we didn't get full metadata but had cached metadata, use that since it might be partial
+                return metadata ?? cachedMetadata;
+            }
+            catch (Exception e)
+            {
+                _logger.ErrorLog($"Failed to get metadata for map '{fileName}': {e.Message}");
+                return null;
+            }
+        }
+    }
+}

--- a/SRCustomLib/MapRepo.cs
+++ b/SRCustomLib/MapRepo.cs
@@ -21,7 +21,7 @@ namespace SRCustomLib
         {
             _logger = logger;
 
-            _customFileManager ??= new CustomFileManager(logger);
+            _customFileManager = customFileManager ?? new CustomFileManager(logger);
             
             _useZ = useZ;
             _useSyn = useSyn;

--- a/SRCustomLib/MapRepo.cs
+++ b/SRCustomLib/MapRepo.cs
@@ -1,4 +1,7 @@
-﻿using SRTimestampLib;
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using SRTimestampLib;
 
 namespace SRCustomLib
 {

--- a/SRCustomLib/MapRepo.cs
+++ b/SRCustomLib/MapRepo.cs
@@ -1,0 +1,88 @@
+﻿using SRTimestampLib;
+
+namespace SRCustomLib
+{
+    /// <summary>
+    /// Retrieve SynthRiders maps from various sources
+    /// </summary>
+    public class MapRepo
+    {
+        private readonly SRLogHandler _logger;
+        private readonly CustomFileManager _customFileManager;
+        private readonly DownloadManagerZ _repoZ;
+        private readonly DownloadManagerSyn _repoSyn;
+        private readonly CustomMapRepoTorrent _repoTorrent;
+
+        private bool _useZ;
+        private bool _useSyn;
+        private bool _useTorrent;
+        
+        public MapRepo(SRLogHandler logger, bool useZ = true, bool useSyn = true, bool useTorrent = true, CustomFileManager? customFileManager = null)
+        {
+            _logger = logger;
+
+            _customFileManager ??= new CustomFileManager(logger);
+            
+            _useZ = useZ;
+            _useSyn = useSyn;
+            _useTorrent = useTorrent;
+            
+            _repoZ = new DownloadManagerZ(logger, _customFileManager);
+            _repoSyn = new DownloadManagerSyn(logger, _customFileManager);
+            _repoTorrent = new CustomMapRepoTorrent(logger);
+        }
+
+        public async Task Initialize()
+        {
+            await _customFileManager.Initialize();
+
+            // Start with a clean download dir, so everything can be moved over via the torrent itself
+            FileUtils.EmptyDirectory(FileUtils.TorrentDownloadDirectory);
+        }
+        
+        /// <summary>
+        /// Tries to download songs since the given cutoffTime, with any of the given difficulties, from various sources (fallbacks as necessary)
+        /// </summary>
+        /// <param name="cutoffTimeUtc"></param>
+        /// <param name="difficultySelections"></param>
+        /// <returns></returns>
+        public async Task<bool> TryDownloadWithFallbacks(DateTime cutoffTimeUtc, List<string>? difficultySelections)
+        {
+            var success = false;
+
+            // First, try Z download
+            if (_useZ)
+            {
+                _logger.DebugLog("Attempting to download from Z...");
+                success = await _repoZ.DownloadSongsSinceTime(cutoffTimeUtc, difficultySelections);
+            }
+        
+            if (!success && _useSyn)
+            {
+                // Fallback on synplicity
+                _logger.DebugLog("Attempting to download from Synplicity...");
+                return await _repoSyn.DownloadSongsSinceTime(cutoffTimeUtc, difficultySelections);
+            }
+
+            if (!success && _useTorrent)
+            {
+                // Fallback on torrent
+
+                // Ensure the torrent repo is initialized. Done here so it doesn't have to happen if we have a working site
+                if (!_repoTorrent.IsInitialized)
+                {
+                    _logger.DebugLog("Setting up torrent map source...");
+                    await _repoTorrent.Initialize();
+                }
+
+                _logger.DebugLog("Attempting to download from torrent...");
+                // TODO get difficulty info to filter from torrent as well
+                var diffSet = difficultySelections == null ? new() : new HashSet<string>(difficultySelections);
+                var downloadedMaps = await _repoTorrent.DownloadMaps(null, cutoffTimeUtc);
+                success = downloadedMaps != null;
+            }
+
+            return success;
+        }
+    }
+}

--- a/SRCustomLib/MapRepo.cs
+++ b/SRCustomLib/MapRepo.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using SRTimestampLib;
 
@@ -32,7 +33,7 @@ namespace SRCustomLib
             
             _repoZ = new DownloadManagerZ(logger, _customFileManager);
             _repoSyn = new DownloadManagerSyn(logger, _customFileManager);
-            _repoTorrent = new CustomMapRepoTorrent(logger);
+            _repoTorrent = new CustomMapRepoTorrent(logger, _customFileManager);
         }
 
         public async Task Initialize()
@@ -49,7 +50,7 @@ namespace SRCustomLib
         /// <param name="cutoffTimeUtc"></param>
         /// <param name="difficultySelections"></param>
         /// <returns></returns>
-        public async Task<bool> TryDownloadWithFallbacks(DateTime cutoffTimeUtc, List<string>? difficultySelections)
+        public async Task<bool> TryDownloadWithFallbacks(DateTime cutoffTimeUtc, List<string>? difficultySelections, CancellationToken cancellationToken)
         {
             var success = false;
 
@@ -57,14 +58,14 @@ namespace SRCustomLib
             if (_useZ)
             {
                 _logger.DebugLog("Attempting to download from Z...");
-                success = await _repoZ.DownloadSongsSinceTime(cutoffTimeUtc, difficultySelections);
+                success = await _repoZ.DownloadSongsSinceTime(cutoffTimeUtc, difficultySelections, cancellationToken);
             }
         
             if (!success && _useSyn)
             {
                 // Fallback on synplicity
                 _logger.DebugLog("Attempting to download from Synplicity...");
-                return await _repoSyn.DownloadSongsSinceTime(cutoffTimeUtc, difficultySelections);
+                return await _repoSyn.DownloadSongsSinceTime(cutoffTimeUtc, difficultySelections, cancellationToken);
             }
 
             if (!success && _useTorrent)

--- a/SRCustomLib/Models/CachedMapMetadata.cs
+++ b/SRCustomLib/Models/CachedMapMetadata.cs
@@ -1,4 +1,5 @@
-﻿using MemoryPack;
+﻿using System.Collections.Generic;
+using MemoryPack;
 
 namespace SRCustomLib.Models
 {

--- a/SRCustomLib/Models/CachedMapMetadata.cs
+++ b/SRCustomLib/Models/CachedMapMetadata.cs
@@ -1,0 +1,10 @@
+﻿using MemoryPack;
+
+namespace SRCustomLib.Models
+{
+    [MemoryPackable]
+    public partial class CachedMapMetadata
+    {
+        public Dictionary<string, MapMetadata> MetadataByFileName { get; set; } = new();
+    }
+}

--- a/SRCustomLib/Models/MagnetLinkInfo.cs
+++ b/SRCustomLib/Models/MagnetLinkInfo.cs
@@ -1,10 +1,13 @@
 ﻿using System;
 
+// Avoid annoying warnings in Unity
+#nullable enable
+
 namespace SRCustomLib.Models
 {
     public class MagnetLinkInfo
     {
-        public string magnet_uri;
-        public string updated_at;
+        public string? magnet_uri;
+        public string? updated_at;
     }
 }

--- a/SRCustomLib/Models/MagnetLinkInfo.cs
+++ b/SRCustomLib/Models/MagnetLinkInfo.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace SRCustomLib.Models
+{
+    public class MagnetLinkInfo
+    {
+        public string magnet_uri;
+        public string updated_at;
+    }
+}

--- a/SRCustomLib/Models/MapMetadata.cs
+++ b/SRCustomLib/Models/MapMetadata.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using MemoryPack;
 using SRTimestampLib.Models;
 
 // Avoid annoying warnings in Unity
@@ -11,7 +12,8 @@ namespace SRCustomLib.Models
     /// <summary>
     /// Information about a custom map, used for search/filter
     /// </summary>
-    public class MapMetadata
+    [MemoryPackable]
+    public partial class MapMetadata
     {
         public string? FileName { get; set; }
         public string? DownloadedPath { get; set; }

--- a/SRCustomLib/Models/MapMetadata.cs
+++ b/SRCustomLib/Models/MapMetadata.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using SRTimestampLib.Models;
 
 // Avoid annoying warnings in Unity
 #nullable enable
@@ -20,5 +23,21 @@ namespace SRCustomLib.Models
         public string? Mapper { get; set; }
         public long PublishedAtTimestampSec { get; set; }
         public List<string>? SupportedDifficulties { get; set; }
+
+        public static MapMetadata FromMapItem(MapItem mapItem)
+        {
+            DateTime publishedAtTime = mapItem.GetPublishedAtUtc() ?? DateTime.UnixEpoch;
+            return new MapMetadata
+            {
+                FileName = mapItem.filename,
+                Hash = mapItem.hash,
+                MapName = mapItem.title,
+                Mapper = mapItem.mapper,
+                Duration = mapItem.duration,
+                SongArtist = mapItem.artist,
+                PublishedAtTimestampSec = (long)(publishedAtTime - DateTime.UnixEpoch).TotalSeconds,
+                SupportedDifficulties = (mapItem.difficulties ?? Array.Empty<string>()).Where(diff => !string.IsNullOrEmpty(diff)).ToList(),
+            };
+        }
     }
 }

--- a/SRCustomLib/SRCustomLib.csproj
+++ b/SRCustomLib/SRCustomLib.csproj
@@ -14,6 +14,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="MemoryPack" Version="1.21.4" />
       <PackageReference Include="MonoTorrent" Version="3.0.2" />
     </ItemGroup>
 

--- a/SRDownloadAll/SRDownloadAll.cs
+++ b/SRDownloadAll/SRDownloadAll.cs
@@ -30,16 +30,10 @@ class SRDownloadAll
         var logger = new SRLogHandler();
         var customFileManager = new CustomFileManager(logger);
 
+        var mapRepo = new MapRepo(logger, useZ: true, useSyn: true, useTorrent: true, customFileManager);
+
         // Init knowledge of local map files
-        await customFileManager.Initialize();
-
-        var repo = new CustomMapRepoTorrent(logger);
-
-        // Get current state of torrent
-        await repo.Initialize();
-
-        // Start with a clean download dir, so everything can be moved over via the torrent itself
-        FileUtils.EmptyDirectory(FileUtils.TorrentDownloadDirectory);
+        await mapRepo.Initialize();
 
         // Download all missing songs (for now)
         // var lastStartTimeSec = 1738453212L;
@@ -47,34 +41,12 @@ class SRDownloadAll
         logger.DebugLog($"Last fetched time is {lastStartTimeSec}");
         
         // Downloading all; use ridiculously early time as our start
-        var downloadedMaps = await repo.DownloadMaps(includedDifficulties: null, startTime: DateTime.UnixEpoch);
-
-        // Only bother with imports and db updates if there were actually any new songs updated
-        if (downloadedMaps != null && downloadedMaps.Count > 0)
+        bool success = await mapRepo.TryDownloadWithFallbacks(DateTime.UnixEpoch, null);
+        if (success)
         {
-            await customFileManager.AddLocalMaps(downloadedMaps.Select(mapMetadata => mapMetadata.FilePath).ToList());
-            var numProcessed = 0;
-            foreach (var map in downloadedMaps)
-            {
-                await customFileManager.AddLocalMap(map.FilePath, null);
-
-                numProcessed++;
-                if (numProcessed % 10 == 0)
-                {
-                    await Task.Yield();
-                }
-            }
+            customFileManager.db.SetLastDownloadedTime(runStartTime);
             await customFileManager.db.Save();
-        
-            // Might as well fix the timestamps while we're here :)
-            await customFileManager.ApplyLocalMappings(await customFileManager.GetLocalTimestampMappings());
-        
-            // Update the actual SR database as well, for faster game import (and ensured accuracy)
-            await customFileManager.UpdateSynthDBTimestamps();            
         }
-        
-        customFileManager.db.SetLastDownloadedTime(runStartTime);
-        await customFileManager.db.Save();
     }
 }
 #endif

--- a/SRDownloadAll/SRDownloadAll.cs
+++ b/SRDownloadAll/SRDownloadAll.cs
@@ -50,7 +50,7 @@ class SRDownloadAll
         var downloadedMaps = await repo.DownloadMaps(includedDifficulties: null, startTime: DateTime.UnixEpoch);
 
         // Only bother with imports and db updates if there were actually any new songs updated
-        if (downloadedMaps.Count > 0)
+        if (downloadedMaps != null && downloadedMaps.Count > 0)
         {
             await customFileManager.AddLocalMaps(downloadedMaps.Select(mapMetadata => mapMetadata.FilePath).ToList());
             var numProcessed = 0;

--- a/SRDownloadAll/SRDownloadAll.cs
+++ b/SRDownloadAll/SRDownloadAll.cs
@@ -41,7 +41,7 @@ class SRDownloadAll
         logger.DebugLog($"Last fetched time is {lastStartTimeSec}");
         
         // Downloading all; use ridiculously early time as our start
-        bool success = await mapRepo.TryDownloadWithFallbacks(DateTime.UnixEpoch, null);
+        bool success = await mapRepo.TryDownloadWithFallbacks(DateTime.UnixEpoch, null, CancellationToken.None);
         if (success)
         {
             customFileManager.db.SetLastDownloadedTime(runStartTime);

--- a/SRTimestampLib/CustomFileManager.cs
+++ b/SRTimestampLib/CustomFileManager.cs
@@ -321,6 +321,7 @@ namespace SRTimestampLib
             }
 
             var localTimestampMapping = JsonConvert.DeserializeObject<List<MapItem>>(File.ReadAllText(localTimestampMapFile));
+            await Task.CompletedTask;
 #endif
             
             if (localTimestampMapping == null || localTimestampMapping.Count == 0)

--- a/SRTimestampLib/CustomFileManager.cs
+++ b/SRTimestampLib/CustomFileManager.cs
@@ -250,7 +250,7 @@ namespace SRTimestampLib
         /// Parses local map file. Returns null if can't parse or no metadata
         public static async Task<MapZMetadata?> ParseLocalMap(string filePath, SRLogHandler logger, MapItem? mapFromZ = null)
         {
-            // logger.DebugLog($"Parsing map at {filePath}");
+            logger.DebugLog($"Parsing map at {filePath}");
             var metadataFileName = "synthriderz.meta.json";
             try
             {

--- a/SRTimestampLib/CustomFileManager.cs
+++ b/SRTimestampLib/CustomFileManager.cs
@@ -229,7 +229,7 @@ namespace SRTimestampLib
             db.RemoveMissingHashes(localHashes);
 
             // Save to db for next run
-            if (!await db.Save())
+            if (!await db.Save(true))
             {
                 logger.ErrorLog("Failed to save db");
                 // ignore for now; we still loaded everything fine
@@ -256,7 +256,7 @@ namespace SRTimestampLib
         /// Parses local map file. Returns null if can't parse or no metadata
         public static async Task<MapZMetadata?> ParseLocalMap(string filePath, SRLogHandler logger, MapItem? mapFromZ = null)
         {
-            logger.DebugLog($"Parsing map at {filePath}");
+            // logger.DebugLog($"Parsing map at {filePath}");
             var metadataFileName = "synthriderz.meta.json";
             try
             {

--- a/SRTimestampLib/FileUtils.cs
+++ b/SRTimestampLib/FileUtils.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using MemoryPack;
 using Newtonsoft.Json;

--- a/SRTimestampLib/FileUtils.cs
+++ b/SRTimestampLib/FileUtils.cs
@@ -3,7 +3,6 @@ using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
-using UnityEngine.Assertions;
 
 // Avoid annoying warnings in Unity
 #nullable enable
@@ -167,9 +166,7 @@ namespace SRTimestampLib
         /// Returns null on failure.
         public static async Task<T?> ReadFileJson<T>(string filePath, SRLogHandler logger)
         {
-            Assert.IsTrue(!string.IsNullOrEmpty(filePath));
-
-            if (!File.Exists(filePath))
+            if (string.IsNullOrEmpty(filePath) || !File.Exists(filePath))
             {
                 return default(T);
             }

--- a/SRTimestampLib/FileUtils.cs
+++ b/SRTimestampLib/FileUtils.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
+using UnityEngine.Assertions;
 
 // Avoid annoying warnings in Unity
 #nullable enable
@@ -72,6 +73,8 @@ namespace SRTimestampLib
         }
 
         public static string CustomSongsPath => Path.Join(SynthCustomContentDir, "CustomSongs");
+        public static string CustomStagesPath => Path.Join(SynthCustomContentDir, "CustomStages");
+        public static string CustomPlaylistsPath => Path.Join(SynthCustomContentDir, "CustomPlaylists");
         public static string SynthDBPath => Path.GetFullPath(Path.Join(SynthCustomContentDir, "SynthDB"));
 
         public static string TempPath
@@ -164,6 +167,13 @@ namespace SRTimestampLib
         /// Returns null on failure.
         public static async Task<T?> ReadFileJson<T>(string filePath, SRLogHandler logger)
         {
+            Assert.IsTrue(!string.IsNullOrEmpty(filePath));
+
+            if (!File.Exists(filePath))
+            {
+                return default(T);
+            }
+
             try
             {
                 using (Stream stream = new FileStream(filePath, FileMode.Open, FileAccess.Read))

--- a/SRTimestampLib/LocalDatabase.cs
+++ b/SRTimestampLib/LocalDatabase.cs
@@ -40,12 +40,16 @@ namespace SRTimestampLib
 
         [JsonIgnore]
         private bool _isDirty;
+        
+        [JsonIgnore]
+        public readonly string Id;
 
         // public LocalDatabase() { }
 
         public LocalDatabase(SRLogHandler logger)
         {
             this.logger = logger;
+            Id = Guid.NewGuid().ToString();
         }
 
         /// Gets locally stored metadata based on file path.
@@ -176,7 +180,7 @@ namespace SRTimestampLib
             {
                 string asJson = JsonConvert.SerializeObject(this, Formatting.Indented);
                 string tempFile = GetTempFilePath();
-                logger.DebugLog($"Saving db ({localMapMetadata.Count} maps)");
+                logger.DebugLog($"Saving db {Id} ({localMapMetadata.Count} maps)");
                 if (!await FileUtils.WriteToFile(asJson, tempFile, logger))
                 {
                     logger.ErrorLog("Failed to write db to temp file");

--- a/SRTimestampLib/Models/LocalMapTimestampMappings.cs
+++ b/SRTimestampLib/Models/LocalMapTimestampMappings.cs
@@ -38,16 +38,22 @@ namespace SRTimestampLib.Models
             }
             //Debug.Log($"Time {mapTimestamp.modified_time} => {dateModifiedUtc.ToString()}");
 
-            if (_hashToDateModifiedUtc.ContainsKey(mapTimestamp.hash))
+            if (_hashToDateModifiedUtc.TryGetValue(mapTimestamp.hash, out var hashDateModified))
             {
-                Debug.LogError($"Duplicate entry in file for hash {mapTimestamp.hash}. Times are {dateModifiedUtc.Value} and {_hashToDateModifiedUtc[mapTimestamp.hash]}");
+                Debug.LogError($"Duplicate entry in file for hash {mapTimestamp.hash}. Times are {dateModifiedUtc.Value} and {hashDateModified}");
                 return;
             }
             _hashToDateModifiedUtc.Add(mapTimestamp.hash, dateModifiedUtc.Value);
-            
-            if (_filenameToDateModifiedUtc.ContainsKey(mapTimestamp.filename))
+
+            if (string.IsNullOrEmpty(mapTimestamp.filename))
             {
-                Debug.LogError($"Duplicate entry in file for filename {mapTimestamp.filename}. Times are {dateModifiedUtc.Value} and {_filenameToDateModifiedUtc[mapTimestamp.filename]}");
+                Debug.LogError($"Null or empty filename being added! Hash is {mapTimestamp.hash}");
+                return;
+            }
+
+            if (_filenameToDateModifiedUtc.TryGetValue(mapTimestamp.filename, out var filenameDateModified))
+            {
+                Debug.LogError($"Duplicate entry in file for filename {mapTimestamp.filename}. Times are {dateModifiedUtc.Value} and {filenameDateModified}");
                 return;
             }
             _filenameToDateModifiedUtc.Add(mapTimestamp.filename, dateModifiedUtc.Value);

--- a/SRTimestampLib/Models/MapItem.cs
+++ b/SRTimestampLib/Models/MapItem.cs
@@ -17,6 +17,10 @@ namespace SRTimestampLib.Models
         public string? uploaded_at { get; set; }
         public string? filename { get; set; }
         public User? user { get; set; }
+        public string[]? difficulties { get; set; }
+        public string? mapper { get; set; }
+        public string? duration { get; set; }
+        public string? artist { get; set; }
 
         public DateTime? GetPublishedAtUtc()
         {

--- a/SRTimestampLib/Models/MapPage.cs
+++ b/SRTimestampLib/Models/MapPage.cs
@@ -1,4 +1,6 @@
-﻿namespace SRTimestampLib.Models
+﻿using System.Collections.Generic;
+
+namespace SRTimestampLib.Models
 {
     public class MapPage
     {

--- a/SRTimestampLib/Models/MapPage.cs
+++ b/SRTimestampLib/Models/MapPage.cs
@@ -1,0 +1,11 @@
+﻿namespace SRTimestampLib.Models
+{
+    public class MapPage
+    {
+        public int count = -1;
+        public int total = -1;
+        public int page = -1;
+        public int pagecount = -1;
+        public List<MapItem> data = new List<MapItem>();
+    }
+}

--- a/SRTimestampLib/SRTimestampLib.csproj
+++ b/SRTimestampLib/SRTimestampLib.csproj
@@ -14,6 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="MemoryPack" Version="1.21.4" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="sqlite-net-pcl" Version="1.9.172" />
   </ItemGroup>


### PR DESCRIPTION
- Downloaders for maps from Z and Synplicity moved over from SRQD, and adapted to run through new HttpUtils in either Unity or .NET
- Cache map metadata retrieved using MemoryPack
- Get torrent mirror file from API