### PR TITLE
Safer overwriting

### DIFF
--- a/SRCustomLib/DownloadManagerZ.cs
+++ b/SRCustomLib/DownloadManagerZ.cs
@@ -18,6 +18,7 @@ namespace SRCustomLib
     /// </summary>
     public class DownloadManagerZ
     {
+        private bool _logVerbose = false;
         public SRLogHandler logger;
         public CustomFileManager customFileManager;
         
@@ -335,34 +336,39 @@ namespace SRCustomLib
                     {
                         notFoundLocally++;
                         // logger.DebugLog($"Map id {mapFromZ.id} not found locally, skipping");
+                        continue;
+                    }
+
+                    var fileName = Path.GetFileName(localMetadata.FilePath);
+                    var publishedAtUtc = mapFromZ.GetPublishedAtUtc();
+                    if (publishedAtUtc == null)
+                    {
+                        logger.DebugLog($"Couldn't parse published_at timestamp {mapFromZ.published_at}");
                     }
                     else
                     {
-                        var fileName = Path.GetFileName(localMetadata.FilePath);
-                        var publishedAtUtc = mapFromZ.GetPublishedAtUtc();
-                        if (publishedAtUtc == null)
+                        if (FileUtils.TryGetDateModifiedUtc(localMetadata.FilePath, logger, out var originalTimeUtc))
                         {
-                            logger.DebugLog($"Couldn't parse published_at timestamp {mapFromZ.published_at}");
+                            if (_logVerbose || originalTimeUtc != publishedAtUtc)
+                            {
+                                logger.DebugLog($"{Path.GetFileNameWithoutExtension(fileName)}: {originalTimeUtc} => {publishedAtUtc}");
+                            }
                         }
-                        else
-                        {
-                            logger.DebugLog($"Setting timestamp for {fileName} to {publishedAtUtc}");
-                            FileUtils.TrySetDateModifiedUtc(localMetadata.FilePath, publishedAtUtc.GetValueOrDefault(), logger);
-                        }
+                        FileUtils.TrySetDateModifiedUtc(localMetadata.FilePath, publishedAtUtc.GetValueOrDefault(), logger);
+                    }
 
-                        numProcessed++;
+                    numProcessed++;
 
-                        // Don't hog main thread
-                        if (numProcessed % 20 == 0)
-                        {
-                            await Task.Yield();
-                        }
+                    // Don't hog main thread
+                    if (numProcessed % 20 == 0)
+                    {
+                        await Task.Yield();
+                    }
 
-                        // Let user know work is happening
-                        if (numProcessed % 100 == 0)
-                        {
-                            logger.DebugLog($"  Processed {numProcessed}/{mapsFromZ.Count}");
-                        }
+                    // Let user know work is happening
+                    if (numProcessed % 100 == 0)
+                    {
+                        logger.DebugLog($"  Processed {numProcessed}/{mapsFromZ.Count}");
                     }
                 }
 

--- a/SRCustomLib/DownloadManagerZ.cs
+++ b/SRCustomLib/DownloadManagerZ.cs
@@ -155,9 +155,15 @@ namespace SRCustomLib
                 string finalPath = customFileManager.MoveCustomSong(destPath, map.GetPublishedAtUtc());
 
                 // logger.DebugLog("Success!");
-                await customFileManager.AddLocalMap(finalPath, map);
+                bool isAdded = await customFileManager.AddLocalMap(finalPath, map);
+                if (!isAdded)
+                {
+                    logger.DebugLog($"Failed to add map with final path {finalPath}");
+                    return false;
+                }
                 
-                // Wait for all other operations to finish, then ensure the timestamp has been set
+                // Wait for all other operations to finish, then ensure the timestamp has been set.
+                // Don't set if there was a problem adding the map (conflict)
                 await Task.Yield();
                 if (map.GetPublishedAtUtc().HasValue)
                 {

--- a/SRTimestampLib/CustomFileManager.cs
+++ b/SRTimestampLib/CustomFileManager.cs
@@ -42,32 +42,16 @@ namespace SRTimestampLib
         }
 
         /// Parses the map at the given path and adds it to the collection
-        public async Task AddLocalMap(string mapPath, MapItem? mapFromZ)
+        public async Task<bool> AddLocalMap(string mapPath, MapItem? mapFromZ)
         {
             var metadata = await ParseLocalMap(mapPath, logger, mapFromZ);
             if (metadata == null)
             {
                 logger.ErrorLog("Failed to parse map " + Path.GetFileNameWithoutExtension(mapPath));
-                return;
+                return false;
             }
 
-            db.AddMap(metadata, logger);
-        }
-
-        public async Task AddLocalMaps(List<string> mapPaths)
-        {
-            var numProcessed = 0;
-            foreach (var mapPath in mapPaths)
-            {
-                await AddLocalMap(mapPath, null);
-
-                numProcessed++;
-                if (numProcessed % 10 == 0)
-                {
-                    await Task.Yield();
-                }
-            }
-            await db.Save();
+            return db.TryAddMap(metadata, logger);
         }
 
         public string[] GetCustomMapPaths() => GetSynthriderzMapFiles(FileUtils.CustomSongsPath);
@@ -196,7 +180,7 @@ namespace SRTimestampLib
                         }
 
                         localHashes.Add(metadata.hash);
-                        db.AddMap(metadata, logger);
+                        _ = db.TryAddMap(metadata, logger);
                     }
 
                     count++;
@@ -252,8 +236,14 @@ namespace SRTimestampLib
 
             return destPath;
         }
-
+        
+        /// <summary>
         /// Parses local map file. Returns null if can't parse or no metadata
+        /// </summary>
+        /// <param name="filePath"></param>
+        /// <param name="logger"></param>
+        /// <param name="mapFromZ"></param>
+        /// <returns></returns>
         public static async Task<MapZMetadata?> ParseLocalMap(string filePath, SRLogHandler logger, MapItem? mapFromZ = null)
         {
             // logger.DebugLog($"Parsing map at {filePath}");
@@ -287,28 +277,27 @@ namespace SRTimestampLib
                     if (mapFromZ == null || mapFromZ.hash == null || mapFromZ.id <= 0)
                     {
                         logger.ErrorLog($"Missing {metadataFileName}!");
+                        return null;
                     }
-                    else
+
+                    // We have information from Z to add this in ourselves
+                    logger.ErrorLog($"Creating missing {metadataFileName} for {fileName}");
+                    try
                     {
-                        // We have information from Z to add this in ourselves
-                        logger.ErrorLog($"Creating missing {metadataFileName} for {fileName}");
-                        try
-                        {
-                            JObject zMetadata = new JObject(
-                                new JProperty("id", mapFromZ.id),
-                                new JProperty("hash", mapFromZ.hash)
-                            );
+                        JObject zMetadata = new JObject(
+                            new JProperty("id", mapFromZ.id),
+                            new JProperty("hash", mapFromZ.hash)
+                        );
 
-                            var newEntry = archive.CreateEntry(metadataFileName);
-                            using StreamWriter streamWriter = new StreamWriter(newEntry.Open());
-                            await streamWriter.WriteAsync(zMetadata.ToString(Formatting.None));
+                        var newEntry = archive.CreateEntry(metadataFileName);
+                        using StreamWriter streamWriter = new StreamWriter(newEntry.Open());
+                        await streamWriter.WriteAsync(zMetadata.ToString(Formatting.None));
 
-                            return new MapZMetadata(mapFromZ.id, mapFromZ.hash, filePath);
-                        }
-                        catch (Exception e)
-                        {
-                            logger.ErrorLog("Failed to create missing metadata entry: " + e.Message);
-                        }
+                        return new MapZMetadata(mapFromZ.id, mapFromZ.hash, filePath);
+                    }
+                    catch (Exception e)
+                    {
+                        logger.ErrorLog("Failed to create missing metadata entry: " + e.Message);
                     }
                 }
             }

--- a/SRTimestampLib/CustomFileManager.cs
+++ b/SRTimestampLib/CustomFileManager.cs
@@ -18,6 +18,8 @@ namespace SRTimestampLib
 {
     public class CustomFileManager
     {
+        public bool _logVerbose = false;
+
         public SRLogHandler logger;
         public LocalDatabase db;
 
@@ -63,7 +65,12 @@ namespace SRTimestampLib
             try
             {
                 var directoryExists = Directory.Exists(rootDirectory);
-                logger.DebugLog($"Getting map files from {rootDirectory}. Directory exists? {directoryExists}");
+
+                if (_logVerbose)
+                {
+                    logger.DebugLog($"Getting map files from {rootDirectory}. Directory exists? {directoryExists}");
+                }
+
                 if (directoryExists)
                 {
                     return Directory.GetFiles(rootDirectory, $"*{MAP_EXTENSION}");
@@ -84,7 +91,12 @@ namespace SRTimestampLib
             try
             {
                 var directoryExists = Directory.Exists(rootDirectory);
-                logger.DebugLog($"Getting stage files from {rootDirectory}. Directory exists? {directoryExists}");
+
+                if (_logVerbose)
+                {
+                    logger.DebugLog($"Getting stage files from {rootDirectory}. Directory exists? {directoryExists}");
+                }
+
                 if (directoryExists)
                 {
                     var filePaths = new List<string>();
@@ -110,7 +122,12 @@ namespace SRTimestampLib
             try
             {
                 var directoryExists = Directory.Exists(rootDirectory);
-                logger.DebugLog($"Getting playlist files from {rootDirectory}. Directory exists? {directoryExists}");
+
+                if (_logVerbose)
+                {
+                    logger.DebugLog($"Getting playlist files from {rootDirectory}. Directory exists? {directoryExists}");
+                }
+
                 if (directoryExists)
                 {
                     var filePaths = new List<string>();
@@ -166,7 +183,10 @@ namespace SRTimestampLib
                     if (dbMetadata != null)
                     {
                         // DB has this version already - good to go
-                        logger.DebugLog(Path.GetFileName(filePath) + " already in db");
+                        if (_logVerbose)
+                        {
+                            logger.DebugLog(Path.GetFileName(filePath) + " already in db");
+                        }
                         localHashes.Add(dbMetadata.hash);
                     }
                     else
@@ -193,7 +213,10 @@ namespace SRTimestampLib
                     
                     if (count % 100 == 0)
                     {
-                        logger.DebugLog($"Processed {count}/{totalFiles}...");
+                        if (_logVerbose)
+                        {
+                            logger.DebugLog($"Processed {count}/{totalFiles}...");
+                        }
 
                         // Save partial progress; ignore errors
                         await db.Save();
@@ -248,6 +271,10 @@ namespace SRTimestampLib
         {
             // logger.DebugLog($"Parsing map at {filePath}");
             var metadataFileName = "synthriderz.meta.json";
+            
+            // Save original time, so if we modify it during reading we can still keep the original file time.
+            bool hasOriginalTime = FileUtils.TryGetDateModifiedUtc(filePath, logger, out var originalDateModifiedUtc);
+
             try
             {
                 using (Stream stream = new FileStream(filePath, FileMode.Open, FileAccess.ReadWrite))
@@ -310,6 +337,14 @@ namespace SRTimestampLib
             catch (System.Exception e)
             {
                 logger.ErrorLog($"Failed to parse local map {Path.GetFileNameWithoutExtension(filePath)}: {e.Message}");
+            }
+            finally
+            {
+                if (hasOriginalTime && File.Exists(filePath))
+                {
+                    // Restore initial time before we changed it by looking (and possibly changing the synth metadata)
+                    FileUtils.TrySetDateModifiedUtc(filePath, originalDateModifiedUtc, logger);
+                }
             }
 
             return null;
@@ -412,6 +447,7 @@ namespace SRTimestampLib
         /// <summary>
         /// Use the local song info to generate a fake, but ordered, timestamp based on the song's id.
         /// Ending timestamp is Jan 2, 2019 (before any maps were uploaded) + id minutes
+        /// Note - this was meant to be a workaround for not having Z times for a while. This is no longer needed, but left for posterity
         /// </summary>
         public void ApplyTimestampsFromIds()
         {

--- a/SRTimestampLib/LocalDatabase.cs
+++ b/SRTimestampLib/LocalDatabase.cs
@@ -81,23 +81,31 @@ namespace SRTimestampLib
             return localMapMetadata.Count;
         }
 
+        /// <summary>
         /// Adds map metadata to database.
-        /// If the file path is already present or hash is already present replace
-        public void AddMap(MapZMetadata mapMeta, SRLogHandler logger)
+        /// If the file path is already present or hash is already present, returns false (caller decides how to handle)
+        /// </summary>
+        /// <param name="mapMeta"></param>
+        /// <param name="logger"></param>
+        public bool TryAddMap(MapZMetadata mapMeta, SRLogHandler logger)
         {
             // Remove existing to replace with new
             if (localMapPathLookup.ContainsKey(mapMeta.FilePath))
             {
-                logger.DebugLog($"Removing map with existing path {mapMeta.FilePath}");
-                localMapMetadata.Remove(localMapPathLookup[mapMeta.FilePath]);
-                localMapPathLookup.Remove(mapMeta.FilePath);
+                logger.ErrorLog($"Map already exists at file path! Skipping. '{mapMeta.FilePath}'");
+                return false;
+                // logger.DebugLog($"Removing map with existing path {mapMeta.FilePath}");
+                // localMapMetadata.Remove(localMapPathLookup[mapMeta.FilePath]);
+                // localMapPathLookup.Remove(mapMeta.FilePath);
             }
 
             if (localMapHashLookup.ContainsKey(mapMeta.hash))
             {
-                logger.DebugLog($"Removing map with matching hash {mapMeta.hash}");
-                localMapMetadata.Remove(localMapHashLookup[mapMeta.hash]);
-                localMapHashLookup.Remove(mapMeta.hash);
+                logger.ErrorLog($"Map with hash '{mapMeta.hash}' already exists! Skipping. File path: '{mapMeta.FilePath}'");
+                return false;
+                // logger.DebugLog($"Removing map with matching hash {mapMeta.hash}");
+                // localMapMetadata.Remove(localMapHashLookup[mapMeta.hash]);
+                // localMapHashLookup.Remove(mapMeta.hash);
             }
 
             logger.DebugLog($"Adding map {Path.GetFileNameWithoutExtension(mapMeta.FilePath)}");
@@ -106,6 +114,7 @@ namespace SRTimestampLib
             localMapMetadata.Add(mapMeta);
 
             _isDirty = true;
+            return true;
         }
 
         /// Remove maps that aren't in the list of hashes

--- a/SRTimestampLib/LocalDatabase.cs
+++ b/SRTimestampLib/LocalDatabase.cs
@@ -15,6 +15,9 @@ namespace SRTimestampLib
     public class LocalDatabase
     {
         [JsonIgnore]
+        private bool _logVerbose = false;
+        
+        [JsonIgnore]
         private readonly string LOCAL_DATABASE_NAME = "SRQD_local.db";
         [JsonIgnore]
         private SRLogHandler logger;
@@ -101,14 +104,17 @@ namespace SRTimestampLib
 
             if (localMapHashLookup.ContainsKey(mapMeta.hash))
             {
-                logger.ErrorLog($"Map with hash '{mapMeta.hash}' already exists! Skipping. File path: '{mapMeta.FilePath}'");
+                logger.ErrorLog($"Map with hash already exists! Skipping. File: '{Path.GetFileNameWithoutExtension(mapMeta.FilePath)}'");
                 return false;
                 // logger.DebugLog($"Removing map with matching hash {mapMeta.hash}");
                 // localMapMetadata.Remove(localMapHashLookup[mapMeta.hash]);
                 // localMapHashLookup.Remove(mapMeta.hash);
             }
 
-            logger.DebugLog($"Adding map {Path.GetFileNameWithoutExtension(mapMeta.FilePath)}");
+            if (_logVerbose)
+            {
+                logger.DebugLog($"Adding map {Path.GetFileNameWithoutExtension(mapMeta.FilePath)}");
+            }
             localMapPathLookup.Add(mapMeta.FilePath, mapMeta);
             localMapHashLookup.Add(mapMeta.hash, mapMeta);
             localMapMetadata.Add(mapMeta);
@@ -132,7 +138,10 @@ namespace SRTimestampLib
 
             foreach (var mapMeta in toRemove)
             {
-                logger.DebugLog($"db map not found in filesystem; removing {Path.GetFileName(mapMeta.FilePath)}");
+                if (_logVerbose)
+                {
+                    logger.DebugLog($"db map not found in filesystem; removing {Path.GetFileName(mapMeta.FilePath)}");
+                }
                 localMapMetadata.Remove(mapMeta);
                 localMapPathLookup.Remove(mapMeta.FilePath);
                 localMapHashLookup.Remove(mapMeta.hash);
@@ -179,7 +188,10 @@ namespace SRTimestampLib
         {
             if (!force && !_isDirty)
             {
-                logger.DebugLog("Skipping save (not dirty)");
+                if (_logVerbose)
+                {
+                    logger.DebugLog("Skipping save (not dirty)");
+                }
                 return true;
             }
 


### PR DESCRIPTION
- Get file time and restore it after parsing the synth file
- Stop handling files with duplicate paths or hashes (let the user sort those out). 
- Reduce logging

These changes seem to fix most timestamp issues noticed by Chip