### PR TITLE
Expose new maps found count for zero-click UI

### DIFF
--- a/SRCustomLib/DownloadManagerZ.cs
+++ b/SRCustomLib/DownloadManagerZ.cs
@@ -45,8 +45,11 @@ namespace SRCustomLib
         /// <param name="sinceTime"></param>
         /// <param name="selectedDifficulties"></param>
         /// <returns>True if successfully downloaded (or attempted but none to download). False on failure (i.e. Z is down)</returns>
+        public int LastNewMapsFound { get; private set; }
+
         public async Task<bool> DownloadSongsSinceTime(DateTimeOffset sinceTime, List<string>? selectedDifficulties, CancellationToken cancellationToken)
         {
+            LastNewMapsFound = 0;
             logger.DebugLog($"Getting maps after time {sinceTime.ToLocalTime()}...");
 
             var tempDir = Path.Join(FileUtils.TempPath, "Download");
@@ -77,6 +80,7 @@ namespace SRCustomLib
                 logger.DebugLog($"{mapsFromSite.Count} maps found since given time for given difficulties.");
 
                 var mapsToDownload = customFileManager.FilterOutExistingMaps(mapsFromSite);
+                LastNewMapsFound = mapsToDownload.Count;
                 logger.DebugLog($"{mapsToDownload.Count} new files to download...");
 
                 int count = 1;

--- a/SRCustomLib/MapRepo.cs
+++ b/SRCustomLib/MapRepo.cs
@@ -21,6 +21,8 @@ namespace SRCustomLib
         private bool _useSyn;
         private bool _useTorrent;
         
+        public int LastNewMapsFound { get; private set; }
+        
         public MapRepo(SRLogHandler logger, bool useZ = true, bool useSyn = true, bool useTorrent = true, CustomFileManager? customFileManager = null)
         {
             _logger = logger;
@@ -53,19 +55,29 @@ namespace SRCustomLib
         public async Task<bool> TryDownloadWithFallbacks(DateTime cutoffTimeUtc, List<string>? difficultySelections, CancellationToken cancellationToken)
         {
             var success = false;
+            LastNewMapsFound = 0;
 
             // First, try Z download
             if (_useZ)
             {
                 _logger.DebugLog("Attempting to download from Z...");
                 success = await _repoZ.DownloadSongsSinceTime(cutoffTimeUtc, difficultySelections, cancellationToken);
+                if (success)
+                {
+                    LastNewMapsFound = _repoZ.LastNewMapsFound;
+                }
             }
         
             if (!success && _useSyn)
             {
                 // Fallback on synplicity
                 _logger.DebugLog("Attempting to download from Synplicity...");
-                return await _repoSyn.DownloadSongsSinceTime(cutoffTimeUtc, difficultySelections, cancellationToken);
+                success = await _repoSyn.DownloadSongsSinceTime(cutoffTimeUtc, difficultySelections, cancellationToken);
+                if (success)
+                {
+                    LastNewMapsFound = _repoSyn.LastNewMapsFound;
+                }
+                return success;
             }
 
             if (!success && _useTorrent)
@@ -84,6 +96,10 @@ namespace SRCustomLib
                 var diffSet = difficultySelections == null ? new() : new HashSet<string>(difficultySelections);
                 var downloadedMaps = await _repoTorrent.DownloadMaps(null, cutoffTimeUtc);
                 success = downloadedMaps != null;
+                if (success)
+                {
+                    LastNewMapsFound = downloadedMaps?.Count ?? 0;
+                }
             }
 
             return success;


### PR DESCRIPTION
## Summary
- Track how many new custom maps were found during an incremental download check
- Expose the count via \MapRepo.LastNewMapsFound\ and \DownloadManagerZ.LastNewMapsFound\

## Why
SRQuestDownloader zero-click mode shows this count on the Fetch button after checking for new customs (e.g. \3 new customs found\).

## Related
Companion PR to bookdude13/SRQuestDownloader (zero-click mode).

## Test plan
- [ ] Run an incremental fetch with zero new maps; count is 0
- [ ] Run with new maps available; count matches maps queued for download

Made with [Cursor](https://cursor.com)